### PR TITLE
Moved meta, hh and log to /data volume for persistence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM resin/rpi-raspbian:wheezy
-MAINTAINER Stefan Biermann <sb@ems-solutions.com> 
+MAINTAINER Stefan Biermann <sb@ems-solutions.com>
 
 # Install InfluxDB
-ENV INFLUXDB_VERSION 0.9.0
+ENV INFLUXDB_VERSION 0.9.6
 ADD src/influxdb_${INFLUXDB_VERSION}_armhf.deb /tmp/influxdb_${INFLUXDB_VERSION}_armhf.dep
 RUN dpkg -i /tmp/influxdb_${INFLUXDB_VERSION}_armhf.dep && \
   rm /tmp/influxdb_${INFLUXDB_VERSION}_armhf.dep && \

--- a/src/config.toml
+++ b/src/config.toml
@@ -1,70 +1,114 @@
-bind-address = "0.0.0.0"
-port = 8086
 reporting-disabled = false
 
 [meta]
   dir = "/data/meta"
-
-[initialization]
-  join-urls = ""
-
-[authentication]
-  enabled = false
-
-[admin]
-  enabled = true
-  port = 8083
-  assets = "/opt/influxdb/current/admin"
-
-[api]
-  bind-address = "0.0.0.0"
-  port = 8086
-
-[collectd]
-  enabled = false
-
-[opentsdb]
-  enabled = false
-
-[udp]
-  enabled = false
-
-[broker]
-  dir = "/data/broker"
-  enabled = true
-  election-timeout = "0"
+  hostname = "localhost"
+  bind-address = ":8088"
+  retention-autocreate = true
+  election-timeout = "1s"
+  heartbeat-timeout = "1s"
+  leader-lease-timeout = "500ms"
+  commit-timeout = "50ms"
+  cluster-tracing = false
+  raft-promotion-enabled = true
+  logging-enabled = true
 
 [data]
   dir = "/data/db"
+  engine = "bz1"
+  max-wal-size = 104857600
+  wal-flush-interval = "10m0s"
+  wal-partition-flush-delay = "2s"
+  wal-dir = "/root/.influxdb/wal"
+  wal-logging-enabled = true
+  wal-ready-series-size = 30720
+  wal-compaction-threshold = 0.5
+  wal-max-series-size = 1048576
+  wal-flush-cold-interval = "5s"
+  wal-partition-size-threshold = 52428800
+  query-log-enabled = true
+  cache-max-memory-size = 524288000
+  cache-snapshot-memory-size = 26214400
+  cache-snapshot-write-cold-duration = "1h0m0s"
+  compact-full-write-cold-duration = "24h0m0s"
+  max-points-per-block = 0
+  data-logging-enabled = true
+
+[cluster]
+  force-remote-mapping = false
+  write-timeout = "5s"
+  shard-writer-timeout = "5s"
+  shard-mapper-timeout = "5s"
+
+[retention]
   enabled = true
-  retention-auto-create = true
-  retention-check-enabled = true
-  retention-check-period = "10m0s"
-  retention-create-period = "45m0s"
+  check-interval = "30m0s"
 
-[snapshot]
-  enabled = false
+[shard-precreation]
+  enabled = true
+  check-interval = "10m0s"
+  advance-period = "30m0s"
 
-[logging]
+[admin]
+  enabled = true
+  bind-address = ":8083"
+  https-enabled = false
+  https-certificate = "/etc/ssl/influxdb.pem"
+
+[monitor]
+  store-enabled = true
+  store-database = "_internal"
+  store-interval = "10s"
+
+[subscriber]
+  enabled = true
+
+[http]
+  enabled = true
+  bind-address = ":8086"
+  auth-enabled = false
+  log-enabled = true
   write-tracing = false
-  raft-tracing = false
-  level  = "info"
-  file   = "/data/log.txt"
-
-[monitoring]
-  enabled = false
-
-[debugging]
   pprof-enabled = false
+  https-enabled = false
+  https-certificate = "/etc/ssl/influxdb.pem"
+
+[collectd]
+  enabled = false
+  bind-address = ":25826"
+  database = "collectd"
+  retention-policy = ""
+  batch-size = 5000
+  batch-pending = 10
+  batch-timeout = "10s"
+  read-buffer = 0
+  typesdb = "/usr/share/collectd/types.db"
+
+[opentsdb]
+  enabled = false
+  bind-address = ":4242"
+  database = "opentsdb"
+  retention-policy = ""
+  consistency-level = "one"
+  tls-enabled = false
+  certificate = "/etc/ssl/influxdb.pem"
+  batch-size = 1000
+  batch-pending = 5
+  batch-timeout = "1s"
+  log-point-errors = true
 
 [continuous_queries]
-  recompute-previous-n = 2
-  recompute-no-older-than = "10m0s"
-  compute-runs-per-interval = 10
-  compute-no-more-than = "2m0s"
-  disabled = false
+  log-enabled = true
+  enabled = true
+  run-interval = "1s"
 
 [hinted-handoff]
   enabled = true
   dir = "/data/hh"
+  max-size = 1073741824
+  max-age = "168h0m0s"
+  retry-rate-limit = 0
+  retry-interval = "1s"
+  retry-max-interval = "1m0s"
+  purge-interval = "1h0m0s"
 

--- a/src/config.toml
+++ b/src/config.toml
@@ -3,7 +3,7 @@ port = 8086
 reporting-disabled = false
 
 [meta]
-  dir = "/var/opt/influxdb/meta"
+  dir = "/data/meta"
 
 [initialization]
   join-urls = ""
@@ -49,7 +49,7 @@ reporting-disabled = false
   write-tracing = false
   raft-tracing = false
   level  = "info"
-  file   = "/opt/influxdb/shared/log.txt"
+  file   = "/data/log.txt"
 
 [monitoring]
   enabled = false
@@ -66,5 +66,5 @@ reporting-disabled = false
 
 [hinted-handoff]
   enabled = true
-  dir = "/var/opt/influxdb/hh"
+  dir = "/data/hh"
 

--- a/src/run.sh
+++ b/src/run.sh
@@ -63,7 +63,7 @@ if [ -n "${PRE_CREATE_DB}" ]; then
         echo "=> Database had been created before, skipping ..."
     else
         echo "=> Starting InfluxDB ..."
-        exec /opt/influxdb/influxd -config=${CONFIG_FILE} &
+        exec /usr/bin/influxd -config=${CONFIG_FILE} &
         PASS=${INFLUXDB_INIT_PWD:-root}
         arr=$(echo ${PRE_CREATE_DB} | tr ";" "\n")
 
@@ -71,7 +71,7 @@ if [ -n "${PRE_CREATE_DB}" ]; then
         RET=1
         while [[ RET -ne 0 ]]; do
             echo "=> Waiting for confirmation of InfluxDB service startup ..."
-            sleep 3 
+            sleep 3
             curl -k ${API_URL}/ping 2> /dev/null
             RET=$?
         done
@@ -80,7 +80,7 @@ if [ -n "${PRE_CREATE_DB}" ]; then
         for x in $arr
         do
             echo "=> Creating database: ${x}"
-            /opt/influxdb/influx -host=localhost -port=8086 -username=root -password="${PASS}" -execute="create database \"${x}\""
+            /usr/bin/influx -host=localhost -port=8086 -username=root -password="${PASS}" -execute="create database \"${x}\""
         done
         echo ""
 
@@ -94,5 +94,5 @@ fi
 
 echo "=> Starting InfluxDB ..."
 
-exec /opt/influxdb/influxd -config=${CONFIG_FILE}
+exec /usr/bin/influxd -config=${CONFIG_FILE}
 


### PR DESCRIPTION
Hi,

I've moved the meta, hh and log files to /data.
This way you can persistent everything by mounting the /data volume to a folder on the host system.

Thanks for creating this Docker container!
